### PR TITLE
circleci: add CI to tilt-apiserver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2.1
+orbs:
+  slack: circleci/slack@3.3.0
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.14
+    working_directory: /go/src/github.com/tilt-dev/tilt-apiserver
+    steps:
+      - checkout
+      - run: make test verify-generate
+      - slack/notify-on-failure:
+          only_for_branches: master
+        
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # tilt-apiserver
+
+[![Build Status](https://circleci.com/gh/tilt-dev/tilt-apiserver/tree/main.svg?style=shield)](https://circleci.com/gh/tilt-dev/tilt-apiserver)
+[![GoDoc](https://godoc.org/github.com/tilt-dev/tilt-apiserver?status.svg)](https://pkg.go.dev/github.com/tilt-dev/tilt-apiserver)
+
 Experimental Tilt apiserver based on kubernetes/apiserver
+


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/circleci:

607a3bbc63ed5ed3b1e3b13e024abdcb0df23572 (2021-02-09 13:04:53 -0500)
circleci: add CI to tilt-apiserver

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics