### PR TITLE
apis: make manifests non-namespaced

### DIFF
--- a/pkg/apis/core/v1alpha1/manifest_types.go
+++ b/pkg/apis/core/v1alpha1/manifest_types.go
@@ -28,6 +28,7 @@ import (
 )
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Manifest

--- a/pkg/generated/clientset/versioned/typed/core/v1alpha1/core_client.go
+++ b/pkg/generated/clientset/versioned/typed/core/v1alpha1/core_client.go
@@ -33,8 +33,8 @@ type CoreV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *CoreV1alpha1Client) Manifests(namespace string) ManifestInterface {
-	return newManifests(c, namespace)
+func (c *CoreV1alpha1Client) Manifests() ManifestInterface {
+	return newManifests(c)
 }
 
 // NewForConfig creates a new CoreV1alpha1Client for the given config.

--- a/pkg/generated/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
+++ b/pkg/generated/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
@@ -27,8 +27,8 @@ type FakeCoreV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeCoreV1alpha1) Manifests(namespace string) v1alpha1.ManifestInterface {
-	return &FakeManifests{c, namespace}
+func (c *FakeCoreV1alpha1) Manifests() v1alpha1.ManifestInterface {
+	return &FakeManifests{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/generated/clientset/versioned/typed/core/v1alpha1/fake/fake_manifest.go
+++ b/pkg/generated/clientset/versioned/typed/core/v1alpha1/fake/fake_manifest.go
@@ -32,7 +32,6 @@ import (
 // FakeManifests implements ManifestInterface
 type FakeManifests struct {
 	Fake *FakeCoreV1alpha1
-	ns   string
 }
 
 var manifestsResource = schema.GroupVersionResource{Group: "core.tilt.dev", Version: "v1alpha1", Resource: "manifests"}
@@ -42,8 +41,7 @@ var manifestsKind = schema.GroupVersionKind{Group: "core.tilt.dev", Version: "v1
 // Get takes name of the manifest, and returns the corresponding manifest object, and an error if there is any.
 func (c *FakeManifests) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Manifest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(manifestsResource, c.ns, name), &v1alpha1.Manifest{})
-
+		Invokes(testing.NewRootGetAction(manifestsResource, name), &v1alpha1.Manifest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -53,8 +51,7 @@ func (c *FakeManifests) Get(ctx context.Context, name string, options v1.GetOpti
 // List takes label and field selectors, and returns the list of Manifests that match those selectors.
 func (c *FakeManifests) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ManifestList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(manifestsResource, manifestsKind, c.ns, opts), &v1alpha1.ManifestList{})
-
+		Invokes(testing.NewRootListAction(manifestsResource, manifestsKind, opts), &v1alpha1.ManifestList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -75,15 +72,13 @@ func (c *FakeManifests) List(ctx context.Context, opts v1.ListOptions) (result *
 // Watch returns a watch.Interface that watches the requested manifests.
 func (c *FakeManifests) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(manifestsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(manifestsResource, opts))
 }
 
 // Create takes the representation of a manifest and creates it.  Returns the server's representation of the manifest, and an error, if there is any.
 func (c *FakeManifests) Create(ctx context.Context, manifest *v1alpha1.Manifest, opts v1.CreateOptions) (result *v1alpha1.Manifest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(manifestsResource, c.ns, manifest), &v1alpha1.Manifest{})
-
+		Invokes(testing.NewRootCreateAction(manifestsResource, manifest), &v1alpha1.Manifest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +88,7 @@ func (c *FakeManifests) Create(ctx context.Context, manifest *v1alpha1.Manifest,
 // Update takes the representation of a manifest and updates it. Returns the server's representation of the manifest, and an error, if there is any.
 func (c *FakeManifests) Update(ctx context.Context, manifest *v1alpha1.Manifest, opts v1.UpdateOptions) (result *v1alpha1.Manifest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(manifestsResource, c.ns, manifest), &v1alpha1.Manifest{})
-
+		Invokes(testing.NewRootUpdateAction(manifestsResource, manifest), &v1alpha1.Manifest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -105,8 +99,7 @@ func (c *FakeManifests) Update(ctx context.Context, manifest *v1alpha1.Manifest,
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeManifests) UpdateStatus(ctx context.Context, manifest *v1alpha1.Manifest, opts v1.UpdateOptions) (*v1alpha1.Manifest, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(manifestsResource, "status", c.ns, manifest), &v1alpha1.Manifest{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(manifestsResource, "status", manifest), &v1alpha1.Manifest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -116,14 +109,13 @@ func (c *FakeManifests) UpdateStatus(ctx context.Context, manifest *v1alpha1.Man
 // Delete takes name of the manifest and deletes it. Returns an error if one occurs.
 func (c *FakeManifests) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(manifestsResource, c.ns, name), &v1alpha1.Manifest{})
-
+		Invokes(testing.NewRootDeleteAction(manifestsResource, name), &v1alpha1.Manifest{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeManifests) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(manifestsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(manifestsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.ManifestList{})
 	return err
@@ -132,8 +124,7 @@ func (c *FakeManifests) DeleteCollection(ctx context.Context, opts v1.DeleteOpti
 // Patch applies the patch and returns the patched manifest.
 func (c *FakeManifests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Manifest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(manifestsResource, c.ns, name, pt, data, subresources...), &v1alpha1.Manifest{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(manifestsResource, name, pt, data, subresources...), &v1alpha1.Manifest{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/generated/clientset/versioned/typed/core/v1alpha1/manifest.go
+++ b/pkg/generated/clientset/versioned/typed/core/v1alpha1/manifest.go
@@ -32,7 +32,7 @@ import (
 // ManifestsGetter has a method to return a ManifestInterface.
 // A group's client should implement this interface.
 type ManifestsGetter interface {
-	Manifests(namespace string) ManifestInterface
+	Manifests() ManifestInterface
 }
 
 // ManifestInterface has methods to work with Manifest resources.
@@ -52,14 +52,12 @@ type ManifestInterface interface {
 // manifests implements ManifestInterface
 type manifests struct {
 	client rest.Interface
-	ns     string
 }
 
 // newManifests returns a Manifests
-func newManifests(c *CoreV1alpha1Client, namespace string) *manifests {
+func newManifests(c *CoreV1alpha1Client) *manifests {
 	return &manifests{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -67,7 +65,6 @@ func newManifests(c *CoreV1alpha1Client, namespace string) *manifests {
 func (c *manifests) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Manifest, err error) {
 	result = &v1alpha1.Manifest{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("manifests").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -84,7 +81,6 @@ func (c *manifests) List(ctx context.Context, opts v1.ListOptions) (result *v1al
 	}
 	result = &v1alpha1.ManifestList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("manifests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,7 +97,6 @@ func (c *manifests) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("manifests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,7 +107,6 @@ func (c *manifests) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 func (c *manifests) Create(ctx context.Context, manifest *v1alpha1.Manifest, opts v1.CreateOptions) (result *v1alpha1.Manifest, err error) {
 	result = &v1alpha1.Manifest{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("manifests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(manifest).
@@ -125,7 +119,6 @@ func (c *manifests) Create(ctx context.Context, manifest *v1alpha1.Manifest, opt
 func (c *manifests) Update(ctx context.Context, manifest *v1alpha1.Manifest, opts v1.UpdateOptions) (result *v1alpha1.Manifest, err error) {
 	result = &v1alpha1.Manifest{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("manifests").
 		Name(manifest.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -140,7 +133,6 @@ func (c *manifests) Update(ctx context.Context, manifest *v1alpha1.Manifest, opt
 func (c *manifests) UpdateStatus(ctx context.Context, manifest *v1alpha1.Manifest, opts v1.UpdateOptions) (result *v1alpha1.Manifest, err error) {
 	result = &v1alpha1.Manifest{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("manifests").
 		Name(manifest.Name).
 		SubResource("status").
@@ -154,7 +146,6 @@ func (c *manifests) UpdateStatus(ctx context.Context, manifest *v1alpha1.Manifes
 // Delete takes name of the manifest and deletes it. Returns an error if one occurs.
 func (c *manifests) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("manifests").
 		Name(name).
 		Body(&opts).
@@ -169,7 +160,6 @@ func (c *manifests) DeleteCollection(ctx context.Context, opts v1.DeleteOptions,
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("manifests").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -182,7 +172,6 @@ func (c *manifests) DeleteCollection(ctx context.Context, opts v1.DeleteOptions,
 func (c *manifests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Manifest, err error) {
 	result = &v1alpha1.Manifest{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("manifests").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/generated/informers/externalversions/core/v1alpha1/interface.go
+++ b/pkg/generated/informers/externalversions/core/v1alpha1/interface.go
@@ -40,5 +40,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // Manifests returns a ManifestInformer.
 func (v *version) Manifests() ManifestInformer {
-	return &manifestInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &manifestInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/generated/informers/externalversions/core/v1alpha1/manifest.go
+++ b/pkg/generated/informers/externalversions/core/v1alpha1/manifest.go
@@ -41,33 +41,32 @@ type ManifestInformer interface {
 type manifestInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewManifestInformer constructs a new informer for Manifest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewManifestInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredManifestInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewManifestInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredManifestInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredManifestInformer constructs a new informer for Manifest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredManifestInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredManifestInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1alpha1().Manifests(namespace).List(context.TODO(), options)
+				return client.CoreV1alpha1().Manifests().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1alpha1().Manifests(namespace).Watch(context.TODO(), options)
+				return client.CoreV1alpha1().Manifests().Watch(context.TODO(), options)
 			},
 		},
 		&corev1alpha1.Manifest{},
@@ -77,7 +76,7 @@ func NewFilteredManifestInformer(client versioned.Interface, namespace string, r
 }
 
 func (f *manifestInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredManifestInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredManifestInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *manifestInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/generated/listers/core/v1alpha1/expansion_generated.go
+++ b/pkg/generated/listers/core/v1alpha1/expansion_generated.go
@@ -20,7 +20,3 @@ package v1alpha1
 // ManifestListerExpansion allows custom methods to be added to
 // ManifestLister.
 type ManifestListerExpansion interface{}
-
-// ManifestNamespaceListerExpansion allows custom methods to be added to
-// ManifestNamespaceLister.
-type ManifestNamespaceListerExpansion interface{}

--- a/pkg/generated/listers/core/v1alpha1/manifest.go
+++ b/pkg/generated/listers/core/v1alpha1/manifest.go
@@ -30,8 +30,9 @@ type ManifestLister interface {
 	// List lists all Manifests in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.Manifest, err error)
-	// Manifests returns an object that can list and get Manifests.
-	Manifests(namespace string) ManifestNamespaceLister
+	// Get retrieves the Manifest from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.Manifest, error)
 	ManifestListerExpansion
 }
 
@@ -53,41 +54,9 @@ func (s *manifestLister) List(selector labels.Selector) (ret []*v1alpha1.Manifes
 	return ret, err
 }
 
-// Manifests returns an object that can list and get Manifests.
-func (s *manifestLister) Manifests(namespace string) ManifestNamespaceLister {
-	return manifestNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// ManifestNamespaceLister helps list and get Manifests.
-// All objects returned here must be treated as read-only.
-type ManifestNamespaceLister interface {
-	// List lists all Manifests in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.Manifest, err error)
-	// Get retrieves the Manifest from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.Manifest, error)
-	ManifestNamespaceListerExpansion
-}
-
-// manifestNamespaceLister implements the ManifestNamespaceLister
-// interface.
-type manifestNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all Manifests in the indexer for a given namespace.
-func (s manifestNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Manifest, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.Manifest))
-	})
-	return ret, err
-}
-
-// Get retrieves the Manifest from the indexer for a given namespace and name.
-func (s manifestNamespaceLister) Get(name string) (*v1alpha1.Manifest, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the Manifest from the index for a given name.
+func (s *manifestLister) Get(name string) (*v1alpha1.Manifest, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/namespace:

0af457e66d0e8d19cba47b6e280450c0e73ef4ac (2021-02-09 21:26:53 -0500)
apis: make manifests non-namespaced

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics