### PR TITLE
storage: fix finalizers + expand test

### DIFF
--- a/pkg/storage/filepath/jsonfile_rest.go
+++ b/pkg/storage/filepath/jsonfile_rest.go
@@ -236,7 +236,7 @@ func (f *filepathREST) Update(
 		}
 	}
 
-	objMeta, err := meta.Accessor(oldObj)
+	objMeta, err := meta.Accessor(updatedObj)
 	if err != nil {
 		return nil, false, err
 	}
@@ -290,6 +290,7 @@ func (f *filepathREST) Delete(
 	}
 	// loosely adapted from https://github.com/kubernetes/apiserver/blob/947ebe755ed8aed2e0f0f5d6420caad07fc04cc2/pkg/registry/generic/registry/store.go#L854-L877
 	if len(objMeta.GetFinalizers()) != 0 {
+
 		now := metav1.NewTime(time.Now())
 		// per-contract, deletion timestamps can not be unset and can only be moved _earlier_
 		if objMeta.GetDeletionTimestamp() == nil || now.Before(objMeta.GetDeletionTimestamp()) {

--- a/pkg/storage/filepath/jsonfile_rest_test.go
+++ b/pkg/storage/filepath/jsonfile_rest_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,6 +57,8 @@ func TestFilepathREST_Delete_NoFinalizers(t *testing.T) {
 
 	e := <-w.ResultChan()
 	assert.Equal(t, watch.Deleted, e.Type)
+
+	f.mustNotExist("test-obj")
 }
 
 func TestFilepathREST_Delete_Finalizers(t *testing.T) {
@@ -92,6 +95,19 @@ func TestFilepathREST_Delete_Finalizers(t *testing.T) {
 	// because object was soft-deleted, a modified event is actually fired
 	// for the deletion timestamp + grace period secs changes
 	assert.Equal(t, watch.Modified, e.Type)
+
+	// in a normal scenario, a controller would see the deletion timestamp set, run its finalizer(s),
+	// and remove its finalizer(s), triggering another update(s) at which point the entity is finally
+	// deleted once no more finalizers remain
+	f.mustUpdate("test-obj", func(obj runtime.Object) {
+		f.mustMeta(obj).SetFinalizers(nil)
+	})
+
+	// at this point, a delete event should be received
+	e = <-w.ResultChan()
+	assert.Equal(t, watch.Deleted, e.Type)
+
+	f.mustNotExist("test-obj")
 }
 
 type restOptionsGetter struct {
@@ -164,6 +180,20 @@ func (r *restFixture) creater() rest.Creater {
 	return creater
 }
 
+func (r *restFixture) getter() rest.Getter {
+	r.t.Helper()
+	getter, ok := r.rest.(rest.Getter)
+	require.True(r.t, ok, "REST storage is not a rest.Getter")
+	return getter
+}
+
+func (r *restFixture) updater() rest.Updater {
+	r.t.Helper()
+	updater, ok := r.rest.(rest.Updater)
+	require.True(r.t, ok, "REST storage is not a rest.Updater")
+	return updater
+}
+
 func (r *restFixture) deleter() rest.GracefulDeleter {
 	r.t.Helper()
 	deleter, ok := r.rest.(rest.GracefulDeleter)
@@ -205,4 +235,45 @@ func (r *restFixture) mustCreate(obj runtime.Object) runtime.Object {
 	require.NoError(r.t, err)
 	assert.Equal(r.t, "test-obj", objMeta.GetName())
 	return createdObj
+}
+
+func (r *restFixture) mustNotExist(name string) {
+	r.t.Helper()
+	ctx, cancel := r.ctx()
+	defer cancel()
+	_, err := r.getter().Get(ctx, name, nil)
+	apiError, ok := err.(apierrors.APIStatus)
+	require.Truef(r.t, ok && apiError.Status().Code == 404, "Did not receive APIStatus not found error: %v", err)
+}
+
+type objectUpdateFn func(obj runtime.Object)
+
+type objectUpdater struct {
+	updateFn objectUpdateFn
+}
+
+func (o objectUpdater) Preconditions() *metav1.Preconditions {
+	return nil
+}
+
+func (o objectUpdater) UpdatedObject(ctx context.Context, oldObj runtime.Object) (newObj runtime.Object, err error) {
+	toUpdate := oldObj.DeepCopyObject()
+	o.updateFn(toUpdate)
+	return toUpdate, nil
+}
+
+func (r *restFixture) mustUpdate(name string, updateFn objectUpdateFn) runtime.Object {
+	r.t.Helper()
+	ctx, cancel := r.ctx()
+	defer cancel()
+
+	updater := objectUpdater{updateFn: updateFn}
+
+	updatedObj, created, err := r.updater().Update(ctx, name, updater, nil, nil, false, nil)
+	require.NoError(r.t, err)
+	require.False(r.t, created)
+	objMeta, err := meta.Accessor(updatedObj)
+	require.NoError(r.t, err)
+	assert.Equal(r.t, "test-obj", objMeta.GetName())
+	return updatedObj
 }


### PR DESCRIPTION
Accidentally swapped the variable when switching to `meta.Accessor` and as a result realized my test case was insufficient since it didn't catch it.