### PR TITLE
storage: fix wrong error return for create if already exists

### DIFF
--- a/pkg/storage/filepath/jsonfile_rest.go
+++ b/pkg/storage/filepath/jsonfile_rest.go
@@ -166,7 +166,7 @@ func (f *filepathREST) Create(
 	accessor.SetResourceVersion(fmt.Sprintf("%d", atomic.AddInt64(&f.currentVersion, 1)))
 
 	if f.fs.Exists(filename) {
-		return nil, ErrFileNotExists
+		return nil, apierrors.NewAlreadyExists(f.groupResource, accessor.GetName())
 	}
 
 	if err := f.fs.Write(f.codec, filename, obj); err != nil {


### PR DESCRIPTION
Need to return an `AlreadyExistsError` so that downstream consumers
can use things like `apierrors.IsAlreadyExists()`.