### PR TITLE
storage: Status updates should send Update() events to their parent resources

### DIFF
--- a/pkg/server/builder/builder_resource.go
+++ b/pkg/server/builder/builder_resource.go
@@ -10,16 +10,17 @@ import (
 // Registers a request handler for the resource that stores it on the file system.
 func (a *Server) WithResourceFileStorage(obj resource.Object, path string) *Server {
 	fs := filepath.RealFS{}
+	ws := filepath.NewWatchSet()
 	strategy := rest.DefaultStrategy{
 		Object:      obj,
 		ObjectTyper: a.scheme,
 	}
-	a.WithResourceAndHandler(obj, filepath.NewJSONFilepathStorageProvider(obj, path, fs, strategy))
+	a.WithResourceAndHandler(obj, filepath.NewJSONFilepathStorageProvider(obj, path, fs, ws, strategy))
 
 	// automatically create status subresource if the object implements the status interface
 	if _, ok := obj.(resource.ObjectWithStatusSubResource); ok {
 		a.WithSubResourceAndHandler(obj, "status",
-			filepath.NewJSONFilepathStorageProvider(obj, path, fs, rest.StatusSubResourceStrategy{Strategy: strategy}))
+			filepath.NewJSONFilepathStorageProvider(obj, path, fs, ws, rest.StatusSubResourceStrategy{Strategy: strategy}))
 	}
 	return a
 }
@@ -29,16 +30,17 @@ func (a *Server) WithResourceMemoryStorage(obj resource.Object, path string) *Se
 	if a.memoryFS == nil {
 		a.memoryFS = filepath.NewMemoryFS()
 	}
+	ws := filepath.NewWatchSet()
 	strategy := rest.DefaultStrategy{
 		Object:      obj,
 		ObjectTyper: a.scheme,
 	}
-	a.WithResourceAndHandler(obj, filepath.NewJSONFilepathStorageProvider(obj, path, a.memoryFS, strategy))
+	a.WithResourceAndHandler(obj, filepath.NewJSONFilepathStorageProvider(obj, path, a.memoryFS, ws, strategy))
 
 	// automatically create status subresource if the object implements the status interface
 	if _, ok := obj.(resource.ObjectWithStatusSubResource); ok {
 		a.WithSubResourceAndHandler(obj, "status",
-			filepath.NewJSONFilepathStorageProvider(obj, path, a.memoryFS, rest.StatusSubResourceStrategy{Strategy: strategy}))
+			filepath.NewJSONFilepathStorageProvider(obj, path, a.memoryFS, ws, rest.StatusSubResourceStrategy{Strategy: strategy}))
 	}
 	return a
 }

--- a/pkg/storage/filepath/jsonfile.go
+++ b/pkg/storage/filepath/jsonfile.go
@@ -26,14 +26,12 @@ import (
 //                      --- resource2
 //                      |
 //                      --- resource3
+// Args:
 //
-// An example of storing example resource to local filepath will be:
-//
-//     builder.APIServer.
-//       WithResourceAndHandler(&v1alpha1.ExampleResource{},
-//             jsonfile.NewJsonFileStorageProvider(&v1alpha1.ExampleResource{}, /*the root file-path*/ "data")).
-//       Build()
-func NewJSONFilepathStorageProvider(obj resource.Object, rootPath string, fs FS, strategy Strategy) builderrest.ResourceHandlerProvider {
+// fs: An abstraction over the filesystem, so that the JSON can be stored in memory or on-disk.
+// watchSet: Storage for watchers to be notified of this resource type. Each type should have its own
+//    WatchSet, but subresources (like the status subresource) should share a WatchSet with their parent.
+func NewJSONFilepathStorageProvider(obj resource.Object, rootPath string, fs FS, watchSet *WatchSet, strategy Strategy) builderrest.ResourceHandlerProvider {
 	return func(scheme *runtime.Scheme, getter generic.RESTOptionsGetter) (rest.Storage, error) {
 		gr := obj.GetGroupVersionResource().GroupResource()
 		opt, err := getter.GetRESTOptions(gr)
@@ -43,6 +41,7 @@ func NewJSONFilepathStorageProvider(obj resource.Object, rootPath string, fs FS,
 		codec := opt.StorageConfig.Codec
 		return NewFilepathREST(
 			fs,
+			watchSet,
 			strategy,
 			gr,
 			codec,

--- a/pkg/storage/filepath/jsonfile_rest_test.go
+++ b/pkg/storage/filepath/jsonfile_rest_test.go
@@ -134,6 +134,7 @@ func newRESTFixture(t *testing.T) *restFixture {
 	t.Helper()
 
 	fs := filepath.NewMemoryFS()
+	ws := filepath.NewWatchSet()
 
 	dir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "_", -1))
 	require.NoError(t, err)
@@ -148,6 +149,7 @@ func newRESTFixture(t *testing.T) *restFixture {
 		&obj,
 		dir,
 		fs,
+		ws,
 		builderrest.DefaultStrategy{ObjectTyper: scheme, Object: &obj})
 
 	codec := serializer.NewCodecFactory(scheme).LegacyCodec(v1alpha1.SchemeGroupVersion)

--- a/pkg/storage/filepath/jsonfile_test.go
+++ b/pkg/storage/filepath/jsonfile_test.go
@@ -92,8 +92,9 @@ func newFixture(t *testing.T, fs filepath.FS) *fixture {
 		},
 	}
 
+	ws := filepath.NewWatchSet()
 	strategy := builderrest.DefaultStrategy{ObjectTyper: scheme, Object: &Manifest{}}
-	provider := filepath.NewJSONFilepathStorageProvider(&Manifest{}, dir, fs, strategy)
+	provider := filepath.NewJSONFilepathStorageProvider(&Manifest{}, dir, fs, ws, strategy)
 	storage, err := provider(scheme, options)
 	require.NoError(t, err)
 

--- a/pkg/storage/filepath/watchset.go
+++ b/pkg/storage/filepath/watchset.go
@@ -1,0 +1,65 @@
+package filepath
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// Keeps track of which watches need to be notified
+type WatchSet struct {
+	mu      sync.RWMutex
+	nodes   map[int]*watchNode
+	counter int
+}
+
+func NewWatchSet() *WatchSet {
+	return &WatchSet{
+		nodes: make(map[int]*watchNode, 10),
+	}
+}
+
+// Creates a new watch with a unique id, but
+// does not start sending events to it until start() is called.
+func (s *WatchSet) newWatch() *watchNode {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.counter++
+	return &watchNode{
+		id: s.counter,
+		s:  s,
+		ch: make(chan watch.Event, 10),
+	}
+}
+
+// Start sending events to this watch.
+func (s *WatchSet) start(w *watchNode) {
+	s.mu.Lock()
+	s.nodes[w.id] = w
+	s.mu.Unlock()
+}
+
+func (s *WatchSet) notifyWatchers(ev watch.Event) {
+	s.mu.RLock()
+	for _, w := range s.nodes {
+		w.ch <- ev
+	}
+	s.mu.RUnlock()
+}
+
+type watchNode struct {
+	s  *WatchSet
+	id int
+	ch chan watch.Event
+}
+
+func (w *watchNode) Stop() {
+	w.s.mu.Lock()
+	delete(w.s.nodes, w.id)
+	w.s.mu.Unlock()
+}
+
+func (w *watchNode) ResultChan() <-chan watch.Event {
+	return w.ch
+}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/ch11669:

b78f068c8ceb1ae794a9e76204617cd0901b2a48 (2021-03-18 14:39:26 -0400)
storage: Status updates should send Update() events to their parent resources

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics