### PR TITLE
storage: report errors correctly on delete

### DIFF
--- a/pkg/server/builder/builder_test.go
+++ b/pkg/server/builder/builder_test.go
@@ -14,6 +14,7 @@ import (
 	tiltopenapi "github.com/tilt-dev/tilt-apiserver/pkg/generated/openapi"
 	"github.com/tilt-dev/tilt-apiserver/pkg/server/apiserver"
 	"github.com/tilt-dev/tilt-apiserver/pkg/server/builder"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -152,6 +153,17 @@ func TestUpdateSpectDoesNotUpdateStatus(t *testing.T) {
 	assert.False(t, obj.CreationTimestamp.Time.IsZero())
 	assert.Equal(t, "spec message", obj.Spec.Message)
 	assert.Equal(t, "", obj.Status.Message)
+}
+
+func TestDelete(t *testing.T) {
+	f := newFixture(t)
+	defer f.tearDown()
+
+	client := f.client
+	err := client.CoreV1alpha1().Manifests().Delete(f.ctx, "my-server", metav1.DeleteOptions{})
+	if assert.Error(t, err) {
+		assert.True(t, apierrors.IsNotFound(err), err.Error())
+	}
 }
 
 type createTestCase struct {

--- a/pkg/storage/filepath/jsonfile_rest.go
+++ b/pkg/storage/filepath/jsonfile_rest.go
@@ -274,10 +274,6 @@ func (f *filepathREST) Delete(
 	deleteValidation rest.ValidateObjectFunc,
 	options *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	filename := f.objectFileName(ctx, name)
-	if !f.fs.Exists(filename) {
-		return nil, false, ErrFileNotExists
-	}
-
 	oldObj, err := f.Get(ctx, name, nil)
 	if err != nil {
 		return nil, false, err

--- a/pkg/storage/filepath/jsonfile_test.go
+++ b/pkg/storage/filepath/jsonfile_test.go
@@ -69,6 +69,16 @@ func TestCreateThenReadThenDelete(t *testing.T) {
 	}
 }
 
+func TestDelete(t *testing.T) {
+	for _, fs := range fileSystems() {
+		t.Run(fmt.Sprintf("%T", fs), func(t *testing.T) {
+			f := newFixture(t, fs)
+			defer f.TearDown()
+			f.TestDelete()
+		})
+	}
+}
+
 type fixture struct {
 	t       *testing.T
 	dir     string
@@ -161,6 +171,13 @@ func (f *fixture) TestCreateThenReadThenDelete() {
 	require.NoError(f.t, err)
 
 	_, err = f.storage.Get(context.Background(), "my-manifest", &metav1.GetOptions{})
+	if assert.Error(f.t, err) {
+		assert.True(f.t, apierrors.IsNotFound(err))
+	}
+}
+
+func (f *fixture) TestDelete() {
+	_, _, err := f.storage.Delete(context.Background(), "my-manifest", nil, &metav1.DeleteOptions{})
 	if assert.Error(f.t, err) {
 		assert.True(f.t, apierrors.IsNotFound(err))
 	}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/delete:

0b5f63719ee99ff33534da442540f051c6b06505 (2021-04-02 11:57:03 -0400)
storage: report errors correctly on delete

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics