### PR TITLE
server: limit operations on status subresources

### DIFF
--- a/pkg/server/builder/builder_resource.go
+++ b/pkg/server/builder/builder_resource.go
@@ -19,8 +19,10 @@ func (a *Server) WithResourceFileStorage(obj resource.Object, path string) *Serv
 
 	// automatically create status subresource if the object implements the status interface
 	if _, ok := obj.(resource.ObjectWithStatusSubResource); ok {
+		provider := filepath.NewJSONFilepathStorageProvider(
+			obj, path, fs, ws, rest.StatusSubResourceStrategy{Strategy: strategy})
 		a.WithSubResourceAndHandler(obj, "status",
-			filepath.NewJSONFilepathStorageProvider(obj, path, fs, ws, rest.StatusSubResourceStrategy{Strategy: strategy}))
+			(&statusProvider{Provider: provider}).Get)
 	}
 	return a
 }
@@ -39,8 +41,10 @@ func (a *Server) WithResourceMemoryStorage(obj resource.Object, path string) *Se
 
 	// automatically create status subresource if the object implements the status interface
 	if _, ok := obj.(resource.ObjectWithStatusSubResource); ok {
+		provider := filepath.NewJSONFilepathStorageProvider(
+			obj, path, a.memoryFS, ws, rest.StatusSubResourceStrategy{Strategy: strategy})
 		a.WithSubResourceAndHandler(obj, "status",
-			filepath.NewJSONFilepathStorageProvider(obj, path, a.memoryFS, ws, rest.StatusSubResourceStrategy{Strategy: strategy}))
+			(&statusProvider{Provider: provider}).Get)
 	}
 	return a
 }

--- a/pkg/server/builder/storage_provider.go
+++ b/pkg/server/builder/storage_provider.go
@@ -8,19 +8,19 @@ import (
 	"github.com/tilt-dev/tilt-apiserver/pkg/server/builder/rest"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
-	regsitryrest "k8s.io/apiserver/pkg/registry/rest"
+	registryrest "k8s.io/apiserver/pkg/registry/rest"
 )
 
 // singletonProvider ensures different versions of the same resource share storage
 type singletonProvider struct {
 	sync.Once
 	Provider rest.ResourceHandlerProvider
-	storage  regsitryrest.Storage
+	storage  registryrest.Storage
 	err      error
 }
 
 func (s *singletonProvider) Get(
-	scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (regsitryrest.Storage, error) {
+	scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (registryrest.Storage, error) {
 	s.Once.Do(func() {
 		s.storage, s.err = s.Provider(scheme, optsGetter)
 	})
@@ -37,4 +37,35 @@ func (e errs) Error() string {
 		msgs = append(msgs, e.list[i].Error())
 	}
 	return strings.Join(msgs, "\n")
+}
+
+// Status resources only support: get, update, watch
+type statusStorage struct {
+	registryrest.Updater
+	registryrest.Getter
+}
+
+type statusProvider struct {
+	Provider rest.ResourceHandlerProvider
+}
+
+func (s *statusProvider) Get(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (registryrest.Storage, error) {
+	storage, err := s.Provider(scheme, optsGetter)
+	if err != nil {
+		return nil, err
+	}
+
+	updater, ok := storage.(registryrest.Updater)
+	if !ok {
+		return nil, fmt.Errorf("status storage does not support update: %T", storage)
+	}
+	getter, ok := storage.(registryrest.Getter)
+	if !ok {
+		return nil, fmt.Errorf("status storage does not support get: %T", storage)
+	}
+
+	return &statusStorage{
+		Updater: updater,
+		Getter:  getter,
+	}, nil
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/subresource:

131570e0d00001901f2f9a30cfdf1cf07f139435 (2021-04-08 18:13:39 -0400)
server: limit operations on status subresources
This is mainly so that we don't generate routes like "watch status"
for the purposes of openapi, which we shouldn't really support.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics