### PR TITLE
server: remove internal API versions

### DIFF
--- a/pkg/server/builder/builder_test.go
+++ b/pkg/server/builder/builder_test.go
@@ -241,6 +241,9 @@ func TestValidateOpenAPISpec(t *testing.T) {
 	content := string(contentBytes)
 	assert.Contains(t, content, `"operationId":"watchCoreTiltDevV1alpha1Manifest"`)
 	assert.NotContains(t, content, `"operationId":"watchCoreTiltDevV1alpha1ManifestStatus"`)
+	assert.Contains(t, content,
+		`"x-kubernetes-group-version-kind":[{"group":"core.tilt.dev","kind":"Manifest","version":"v1alpha1"}]`)
+	assert.NotContains(t, content, `__internal`)
 }
 
 func memConnProvider() apiserver.ConnProvider {

--- a/pkg/server/builder/resource/types.go
+++ b/pkg/server/builder/resource/types.go
@@ -116,19 +116,13 @@ type ObjectWithArbitrarySubResource interface {
 // AddToScheme returns a function to add the Objects to the scheme.
 //
 // AddToScheme will register the objects returned by New and NewList under the GroupVersion for each object.
-// AddToScheme will also register the objects under the "__internal" group version for each object that
-// returns true for IsInternalVersion.
 // AddToScheme will register the defaulting function if it implements the Defaulter inteface.
 func AddToScheme(objs ...Object) func(s *runtime.Scheme) error {
 	return func(s *runtime.Scheme) error {
 		for i := range objs {
 			obj := objs[i]
 			s.AddKnownTypes(obj.GetGroupVersionResource().GroupVersion(), obj.New(), obj.NewList())
-			if obj.IsStorageVersion() {
-				s.AddKnownTypes(schema.GroupVersion{
-					Group:   runtime.APIVersionInternal,
-					Version: obj.GetGroupVersionResource().Version}, obj.New(), obj.NewList())
-			} else {
+			if !obj.IsStorageVersion() {
 				multiVersionObj, ok := obj.(MultiVersionObject)
 				if !ok {
 					return fmt.Errorf("resource should implement MultiVersionObject if it's not storage-version")


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/internal:

e3ca972e968f9810ca6bd04e4cb41d91b506dae4 (2021-04-08 19:58:14 -0400)
server: remove internal API versions
We don't use them and they're very confusing when you hit them.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics