### PR TITLE
storage: prevent stale writes in MemoryFS

### DIFF
--- a/pkg/storage/filepath/jsonfile_rest_test.go
+++ b/pkg/storage/filepath/jsonfile_rest_test.go
@@ -142,7 +142,7 @@ func TestFilepathREST_Update_OptimisticConcurrency(t *testing.T) {
 	})
 
 	require.EqualError(t, err,
-		`Operation cannot be fulfilled on Manifest.core.tilt.dev "test-obj": object was modified`)
+		`Operation cannot be fulfilled on manifests.core.tilt.dev "test-obj": the object has been modified; please apply your changes to the latest version and try again`)
 	require.Nil(t, obj)
 
 	obj, err = f.get("test-obj")
@@ -190,7 +190,7 @@ func TestFilepathREST_Update_OptimisticConcurrency_Subresource(t *testing.T) {
 	})
 
 	if assert.EqualError(t, err,
-		`Operation cannot be fulfilled on Manifest.core.tilt.dev "test-obj": object was modified`) {
+		`Operation cannot be fulfilled on manifests.core.tilt.dev "test-obj": the object has been modified; please apply your changes to the latest version and try again`) {
 		assert.Nil(t, obj)
 	}
 


### PR DESCRIPTION
Hold object versions in memory and only accept writes if the
version passed matches the object storage version.

Currently, this is needed in addition to the already existing
optimistic concurrency logic due to how we calculate resource versions
currently (global counter, not per-object). We can refactor in the
future to handle this closer to the upstream implementation that
relies on etcd where we capture the storage version up-front (to
pass down to storage layer, exactly like we're doing now), but then
use the various hooks to remove the version before storage and then
re-hydrate it on read.

For now, this is sufficient to prevent bugs at the expense of a bit
of duplicated code.

Currently, this only applies to `MemoryFS` and not `RealFS`, but
in practice, that's fine for right now because of the usage patterns
of those objects currently, which do not have many concurrent writers.