### PR TITLE
storage: prevent optimistic concurrency failures for patch

### DIFF
--- a/pkg/storage/filepath/fs.go
+++ b/pkg/storage/filepath/fs.go
@@ -235,7 +235,7 @@ func (fs *MemoryFS) Write(encoder runtime.Encoder, p string, obj runtime.Object,
 
 	dir[filepath.Base(p)] = versionedData{
 		version: newVersion,
-		data:    append(make([]byte, 0, len(buf.Bytes())), buf.Bytes()...),
+		data:    buf.Bytes(),
 	}
 
 	return nil

--- a/pkg/storage/filepath/fs.go
+++ b/pkg/storage/filepath/fs.go
@@ -48,9 +48,13 @@ func (fs RealFS) EnsureDir(dirname string) error {
 }
 
 func (fs RealFS) Write(encoder runtime.Encoder, filepath string, obj runtime.Object, storageVersion uint64) error {
-	// TODO(milas): use resourceVersion - currently, we only care about in-process synchronization (things would
-	// 	go awry if multiple apiservers were writing to the same files), so we can use an identical strategy to
-	// 	MemoryFS at the expense of limiting writes to 1x concurrent or do something more clever
+	// TODO(milas): use storageVersion to ensure we don't perform stale writes
+	// 	(currently, this isn't a critical priority as our use cases that rely
+	// 	on RealFS do not have simultaneous writers)
+	if err := setResourceVersion(obj, storageVersion+1); err != nil {
+		return err
+	}
+
 	buf := new(bytes.Buffer)
 	if err := encoder.Encode(obj, buf); err != nil {
 		return err
@@ -93,19 +97,22 @@ func (fs RealFS) VisitDir(dirname string, newFunc func() runtime.Object, codec r
 // An in-memory structure that pretends to be a filesystem,
 // and supports all the storage interfaces that RealFS needs.
 type MemoryFS struct {
-	mu       sync.Mutex
-	dir      map[string]interface{}
-	versions map[string]uint64
+	mu  sync.Mutex
+	dir map[string]interface{}
 }
 
 func NewMemoryFS() *MemoryFS {
 	return &MemoryFS{
-		dir:      make(map[string]interface{}),
-		versions: make(map[string]uint64),
+		dir: make(map[string]interface{}),
 	}
 }
 
 var _ FS = &MemoryFS{}
+
+type versionedData struct {
+	version uint64
+	data    []byte
+}
 
 // Ensures the given directory exists in our in-memory map.
 func (fs *MemoryFS) ensureDir(pathToDir string) (map[string]interface{}, error) {
@@ -148,7 +155,6 @@ func (fs *MemoryFS) Remove(p string) error {
 	}
 
 	delete(dir, filepath.Base(p))
-	delete(fs.versions, filepath.Clean(p))
 	return nil
 }
 
@@ -176,6 +182,16 @@ func (fs *MemoryFS) EnsureDir(dirname string) error {
 
 // Write a copy of the object to our in-memory filesystem.
 func (fs *MemoryFS) Write(encoder runtime.Encoder, p string, obj runtime.Object, storageVersion uint64) error {
+	// temporarily remove the resource version from the object before
+	// serialization, so that objects that are identical besides resource
+	// version serialize the same, allowing us to skip unnecessary writes
+	// (beneficial for preventing unnecessary optimistic concurrency failures
+	// where an update fails because of a changed version despite the object
+	// actually being identical)
+	if err := clearResourceVersion(obj); err != nil {
+		return err
+	}
+
 	// Encoding the object as bytes ensures that our in-memory filesystem
 	// has the same immutability semantics as a real storage system.
 	buf := new(bytes.Buffer)
@@ -186,9 +202,22 @@ func (fs *MemoryFS) Write(encoder runtime.Encoder, p string, obj runtime.Object,
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 
-	versionKey := filepath.Clean(p)
-	if version, ok := fs.versions[versionKey]; ok && version != storageVersion {
+	if rawObj, err := fs.readBuffer(p); err != nil {
+		if os.IsNotExist(err) {
+			// storageVersion == 0 -> this is a create, so it's expected to not exist (continue)
+			// storageVersion != 0 -> object has been deleted, propagate err to avoid a zombie update
+			if storageVersion != 0 {
+				return err
+			}
+		} else {
+			return err
+		}
+	} else if rawObj.version != storageVersion {
+		// this write is outdated
 		return VersionError
+	} else if bytes.Equal(rawObj.data, buf.Bytes()) {
+		// object serialized identically, skip write & version increment
+		return nil
 	}
 
 	dir, err := fs.ensureDir(filepath.Dir(p))
@@ -196,13 +225,18 @@ func (fs *MemoryFS) Write(encoder runtime.Encoder, p string, obj runtime.Object,
 		return err
 	}
 
-	newVersion, err := resourceVersion(obj)
-	if err != nil {
+	// increment the resource version - it's applied to the object pointer for
+	// the caller in addition to being used to ensure the write is valid
+	newVersion := storageVersion + 1
+	if err := setResourceVersion(obj, newVersion); err != nil {
 		return err
 	}
 
-	dir[filepath.Base(p)] = buf
-	fs.versions[versionKey] = newVersion
+	dir[filepath.Base(p)] = versionedData{
+		version: newVersion,
+		data:    append(make([]byte, 0, len(buf.Bytes())), buf.Bytes()...),
+	}
+
 	return nil
 }
 
@@ -214,30 +248,39 @@ func (fs *MemoryFS) Read(decoder runtime.Decoder, p string, newFunc func() runti
 	if err != nil {
 		return nil, err
 	}
-	return fs.decodeBuffer(decoder, buf, newFunc)
-}
 
-func (fs *MemoryFS) readBuffer(p string) (*bytes.Buffer, error) {
-	dir, err := fs.ensureDir(filepath.Dir(p))
+	obj, err := fs.decodeBuffer(decoder, buf, newFunc)
 	if err != nil {
 		return nil, err
 	}
 
-	contents, ok := dir[filepath.Base(p)]
-	if !ok {
-		return nil, os.ErrNotExist
-	}
-	buf, ok := contents.(*bytes.Buffer)
-	if !ok {
-		return nil, os.ErrNotExist
-	}
-	return buf, nil
+	return obj, nil
 }
 
-func (fs *MemoryFS) decodeBuffer(decoder runtime.Decoder, buf *bytes.Buffer, newFunc func() runtime.Object) (runtime.Object, error) {
-	newObj := newFunc()
-	decodedObj, _, err := decoder.Decode(buf.Bytes(), nil, newObj)
+func (fs *MemoryFS) readBuffer(p string) (versionedData, error) {
+	dir, err := fs.ensureDir(filepath.Dir(p))
 	if err != nil {
+		return versionedData{}, err
+	}
+
+	contents, ok := dir[filepath.Base(p)]
+	if !ok {
+		return versionedData{}, os.ErrNotExist
+	}
+	data, ok := contents.(versionedData)
+	if !ok {
+		return versionedData{}, os.ErrNotExist
+	}
+	return data, nil
+}
+
+func (fs *MemoryFS) decodeBuffer(decoder runtime.Decoder, rawObj versionedData, newFunc func() runtime.Object) (runtime.Object, error) {
+	newObj := newFunc()
+	decodedObj, _, err := decoder.Decode(rawObj.data, nil, newObj)
+	if err != nil {
+		return nil, err
+	}
+	if err := setResourceVersion(decodedObj, rawObj.version); err != nil {
 		return nil, err
 	}
 	return decodedObj, nil
@@ -268,14 +311,14 @@ func (fs *MemoryFS) VisitDir(dirname string, newFunc func() runtime.Object, code
 }
 
 // Internal helper for reading the directory. Must hold the mutex.
-func (fs *MemoryFS) readDir(dirname string) ([]string, []*bytes.Buffer, error) {
+func (fs *MemoryFS) readDir(dirname string) ([]string, []versionedData, error) {
 	dir, err := fs.ensureDir(dirname)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	keyPaths := []string{}
-	buffers := []*bytes.Buffer{}
+	buffers := []versionedData{}
 
 	var walk func(ancestorPath string, dir map[string]interface{}) error
 	walk = func(ancestorPath string, dir map[string]interface{}) error {
@@ -294,12 +337,12 @@ func (fs *MemoryFS) readDir(dirname string) ([]string, []*bytes.Buffer, error) {
 				continue
 			}
 
-			newBuf, err := fs.readBuffer(keyPath)
+			rawObj, err := fs.readBuffer(keyPath)
 			if err != nil {
 				return err
 			}
 			keyPaths = append(keyPaths, keyPath)
-			buffers = append(buffers, newBuf)
+			buffers = append(buffers, rawObj)
 		}
 		return nil
 	}

--- a/pkg/storage/filepath/jsonfile_rest.go
+++ b/pkg/storage/filepath/jsonfile_rest.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv"
-	"sync/atomic"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -77,11 +75,10 @@ type filepathREST struct {
 	newFunc     func() runtime.Object
 	newListFunc func() runtime.Object
 
-	strategy       Strategy
-	groupResource  schema.GroupResource
-	fs             FS
-	watchSet       *WatchSet
-	currentVersion uint64
+	strategy      Strategy
+	groupResource schema.GroupResource
+	fs            FS
+	watchSet      *WatchSet
 }
 
 func (f *filepathREST) notifyWatchers(ev watch.Event) {
@@ -175,14 +172,12 @@ func (f *filepathREST) Create(
 		return nil, err
 	}
 	filename := f.objectFileName(ctx, accessor.GetName())
-	version := atomic.AddUint64(&f.currentVersion, 1)
-	accessor.SetResourceVersion(fmt.Sprintf("%d", version))
 
 	if f.fs.Exists(filename) {
 		return nil, apierrors.NewAlreadyExists(f.groupResource, accessor.GetName())
 	}
 
-	if err := f.fs.Write(f.codec, filename, obj, version); err != nil {
+	if err := f.fs.Write(f.codec, filename, obj, 0); err != nil {
 		if errors.Is(err, VersionError) {
 			err = f.conflictErr(accessor.GetName())
 		}
@@ -206,110 +201,125 @@ func (f *filepathREST) Update(
 	forceAllowCreate bool,
 	options *metav1.UpdateOptions,
 ) (runtime.Object, bool, error) {
-	isCreate := false
-	oldObj, err := f.Get(ctx, name, nil)
-	if err != nil {
-		if !forceAllowCreate {
-			return nil, false, err
+	var isCreate bool
+	var isDelete bool
+	obj, err := f.guaranteedUpdate(ctx, name, func(input runtime.Object) (output runtime.Object, err error) {
+		isCreate = false
+		if input == nil {
+			if !forceAllowCreate {
+				return nil, apierrors.NewNotFound(f.groupResource, name)
+			}
+			isCreate = true
 		}
-		isCreate = true
-	}
-	oldVersion, err := resourceVersion(oldObj)
-	if err != nil {
-		return nil, false, err
-	}
-
-	// TODO: should not be necessary, verify Get works before creating filepath
-	if f.NamespaceScoped() {
-		// ensures namespace dir
-		ns, ok := genericapirequest.NamespaceFrom(ctx)
-		if !ok {
-			return nil, false, ErrNamespaceNotExists
+		inputVersion, err := getResourceVersion(input)
+		if err != nil {
+			return nil, err
 		}
-		if err := f.fs.EnsureDir(filepath.Join(f.objRootPath, ns)); err != nil {
-			return nil, false, err
+
+		// TODO: should not be necessary, verify Get works before creating filepath
+		if f.NamespaceScoped() {
+			// ensures namespace dir
+			ns, ok := genericapirequest.NamespaceFrom(ctx)
+			if !ok {
+				return nil, ErrNamespaceNotExists
+			}
+			if err := f.fs.EnsureDir(filepath.Join(f.objRootPath, ns)); err != nil {
+				return nil, err
+			}
 		}
-	}
 
-	updatedObj, err := objInfo.UpdatedObject(ctx, oldObj)
+		output, err = objInfo.UpdatedObject(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+
+		// this check MUST happen before rest.BeforeUpdate is called - for subresource updates, it'll
+		// use the input (storage version) to copy the subresource to (to avoid changing the spec),
+		// so the version from the request object will be lost, breaking optimistic concurrency
+		updatedVersion, err := getResourceVersion(output)
+		if err != nil {
+			return nil, err
+		}
+		if inputVersion != updatedVersion {
+			return nil, f.conflictErr(name)
+		}
+
+		if err := rest.BeforeUpdate(f.strategy, ctx, output, input); err != nil {
+			return nil, err
+		}
+
+		if isCreate {
+			if createValidation != nil {
+				if err := createValidation(ctx, input); err != nil {
+					return nil, err
+				}
+			}
+			return output, nil
+		}
+
+		if updateValidation != nil {
+			if err := updateValidation(ctx, output, input); err != nil {
+				return nil, err
+			}
+		}
+
+		outputMeta, err := meta.Accessor(output)
+		if err != nil {
+			return nil, err
+		}
+
+		// handle 2-phase deletes -> for entities with finalizers, DeletionTimestamp is set and reconcilers execute +
+		// remove them (triggering more updates); once drained, it can be deleted from the final update operation
+		// loosely based off https://github.com/kubernetes/apiserver/blob/947ebe755ed8aed2e0f0f5d6420caad07fc04cc2/pkg/registry/generic/registry/store.go#L624
+		if len(outputMeta.GetFinalizers()) == 0 && !outputMeta.GetDeletionTimestamp().IsZero() {
+			// to simplify semantics here, we allow this update to go through and then
+			// delete it - if this becomes a bottleneck (seems unlikely), we can delete
+			// here and return a special sentinel error
+			isDelete = true
+			return output, nil
+		}
+
+		return output, nil
+	})
 	if err != nil {
+		// TODO(milas): we need a better way of handling standard errors and
+		// 	wrapping any others in generic apierrors - returning plain Go errors
+		// 	(which still happens in some code paths) makes apiserver log out
+		// 	warnings, though it doesn't actually break things so is not critical
+		if os.IsNotExist(err) {
+			return nil, false, apierrors.NewNotFound(f.groupResource, name)
+		}
 		return nil, false, err
 	}
-
-	// this check MUST happen before rest.BeforeUpdate is called - for subresource updates, it'll
-	// use the oldObj (storage version) to copy the subresource to (to avoid changing the spec),
-	// so the version from the request object will be lost, breaking optimistic concurrency
-	updatedVersion, err := resourceVersion(updatedObj)
-	if err != nil {
-		return nil, false, err
-	}
-	if oldVersion != updatedVersion {
-		return nil, false, f.conflictErr(name)
-	}
-
-	if err := rest.BeforeUpdate(f.strategy, ctx, updatedObj, oldObj); err != nil {
-		return nil, false, err
-	}
-
-	filename := f.objectFileName(ctx, name)
 
 	if isCreate {
-		if createValidation != nil {
-			if err := createValidation(ctx, updatedObj); err != nil {
-				return nil, false, err
-			}
-		}
-		if err := f.fs.Write(f.codec, filename, updatedObj, oldVersion); err != nil {
-			if errors.Is(err, VersionError) {
-				err = f.conflictErr(name)
-			}
-			return nil, false, err
-		}
 		f.notifyWatchers(watch.Event{
 			Type:   watch.Added,
-			Object: updatedObj,
+			Object: obj,
 		})
-		return updatedObj, true, nil
+		return obj, true, nil
 	}
 
-	if updateValidation != nil {
-		if err := updateValidation(ctx, updatedObj, oldObj); err != nil {
-			return nil, false, err
-		}
-	}
-
-	updatedMeta, err := meta.Accessor(updatedObj)
-	if err != nil {
-		return nil, false, err
-	}
-
-	updatedMeta.SetResourceVersion(fmt.Sprintf("%d", atomic.AddUint64(&f.currentVersion, 1)))
-
-	// handle 2-phase deletes -> for entities with finalizers, DeletionTimestamp is set and reconcilers execute +
-	// remove them (triggering more updates); once drained, it can be deleted from the final update operation
-	// loosely based off https://github.com/kubernetes/apiserver/blob/947ebe755ed8aed2e0f0f5d6420caad07fc04cc2/pkg/registry/generic/registry/store.go#L624
-	if len(updatedMeta.GetFinalizers()) == 0 && !updatedMeta.GetDeletionTimestamp().IsZero() {
+	if isDelete {
+		filename := f.objectFileName(ctx, name)
 		if err := f.fs.Remove(filename); err != nil {
+			if os.IsNotExist(err) {
+				return nil, false, apierrors.NewNotFound(f.groupResource, name)
+			}
 			return nil, false, err
 		}
 		f.notifyWatchers(watch.Event{
 			Type:   watch.Deleted,
-			Object: updatedObj,
+			Object: obj,
 		})
-		return updatedObj, false, nil
+		return obj, false, nil
 	}
 
-	if err := f.fs.Write(f.codec, filename, updatedObj, oldVersion); err != nil {
-		if errors.Is(err, VersionError) {
-			err = f.conflictErr(name)
-		}
-		return nil, false, err
-	}
 	f.notifyWatchers(watch.Event{
 		Type:   watch.Modified,
-		Object: updatedObj,
+		Object: obj,
 	})
-	return updatedObj, false, nil
+	return obj, false, nil
 }
 
 func (f *filepathREST) Delete(
@@ -342,7 +352,7 @@ func (f *filepathREST) Delete(
 		zero := int64(0)
 		objMeta.SetDeletionGracePeriodSeconds(&zero)
 
-		version, err := resourceVersion(oldObj)
+		version, err := getResourceVersion(oldObj)
 		if err != nil {
 			return nil, false, err
 		}
@@ -423,6 +433,45 @@ func (f *filepathREST) objectDirName(ctx context.Context) string {
 	return filepath.Join(f.objRootPath)
 }
 
+type updateFunc func(input runtime.Object) (output runtime.Object, err error)
+
+func (f *filepathREST) guaranteedUpdate(ctx context.Context, name string, tryUpdate updateFunc) (runtime.Object, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			// the FS layer doesn't use context, so we explicitly check it on
+			// each loop iteration so that we'll stop retrying if the context
+			// gets canceled (e.g. request timeout)
+			return nil, err
+		}
+
+		storageObj, err := f.Get(ctx, name, nil)
+		if err != nil && !apierrors.IsNotFound(err) {
+			// some objects allow create-on-update semantics, so NotFound is not terminal
+			return nil, err
+		}
+		storageVersion, err := getResourceVersion(storageObj)
+		if err != nil {
+			return nil, err
+		}
+
+		out, err := tryUpdate(storageObj)
+		if err != nil {
+			// TODO(milas): check error type and wrap if necessary
+			return nil, err
+		}
+
+		filename := f.objectFileName(ctx, name)
+		if err := f.fs.Write(f.codec, filename, out, storageVersion); err != nil {
+			if errors.Is(err, VersionError) {
+				// storage conflict, retry
+				continue
+			}
+			return nil, err
+		}
+		return out, nil
+	}
+}
+
 func appendItem(v reflect.Value, obj runtime.Object) {
 	v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
 }
@@ -494,16 +543,4 @@ func newSelectionPredicate(options *metainternalversion.ListOptions) storage.Sel
 		}
 	}
 	return p
-}
-
-func resourceVersion(obj runtime.Object) (uint64, error) {
-	objMeta, err := meta.Accessor(obj)
-	if err != nil {
-		return 0, err
-	}
-	version, err := strconv.ParseUint(objMeta.GetResourceVersion(), 10, 0)
-	if err != nil {
-		return 0, err
-	}
-	return version, nil
 }

--- a/pkg/storage/filepath/version.go
+++ b/pkg/storage/filepath/version.go
@@ -1,0 +1,57 @@
+package filepath
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func getResourceVersion(obj runtime.Object) (uint64, error) {
+	if obj == nil {
+		return 0, nil
+	}
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return 0, err
+	}
+	return parseResourceVersion(objMeta.GetResourceVersion())
+}
+
+func setResourceVersion(obj runtime.Object, v uint64) error {
+	if v <= 0 {
+		return fmt.Errorf("resourceVersion must be positive: %d", v)
+	}
+
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	objMeta.SetResourceVersion(formatResourceVersion(v))
+	return nil
+}
+
+func clearResourceVersion(obj runtime.Object) error {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	objMeta.SetResourceVersion("")
+	return nil
+}
+
+func parseResourceVersion(v string) (uint64, error) {
+	if v == "" {
+		return 0, nil
+	}
+	version, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return version, nil
+}
+
+func formatResourceVersion(v uint64) string {
+	return strconv.FormatUint(v, 10)
+}


### PR DESCRIPTION
There's two classes of optimistic concurrency failures:
 1. Object update is outdated by time it's received by server
 2. Object is written to between update start and FS write

The first case should result in an immediate error propagated to
the user - there's no automatic resolution possible on the server.
(This is largely the optimistic concurrency check we've had thus
far.)

The second one is trickier: the first step at addressing this was
done in #53 (d5d681f238e029bfab17c270e3189c09d2d26497), which at
prevents two writes for the same version from succeeding. However,
this means that patch operations can fail due to optimistic
concurrency, which is explicitly against the apiserver contract.

As a result, this adds a "guaranteed update" method (name taken
from the etcd code that does logically the same thing). This will
retry on any FS/storage-level optimistic concurrency issues, by
replaying the whole update attempt from object fetch.

For an object replace, this means if it's valid at operation start
but another operation beats it before it's persisted, it'll retry,
fetch the new version of the object (or `nil` if object was deleted!)
and then trigger the logic to detect (1), as there will now be a
version mismatch _within the update logic_.

For an object patch, the patch will get replayed on the new object
version and persistence re-attempted. This will continue indefinitely
until a write actually succeeds or the context is canceled.

Additionally, to support this, object versioning has been overhauled
so that it's tracked per-object. For `MemoryFS`, it behaves like etcd
storage, where the versions are removed pre-serialization and restored
on read. Internally, the map now holds a tuple of the version and the
object data (eliminating the separate versions map to simplify book
keeping). This also enables an optimization to avoid incrementing the
version if the object hasn't changed at all. This is useful to avoid
unnecessary optimistic concurrency failures (client A submits no-op
update from v1, client B submits real update from v1, previously if
client B was processed after A, it would fail, now it'll still succeed
since A's no-op update will _really_ be a no-op.) This also matches
K8s apiserver/etcd behavior.

TL;DR Optimistic concurrency is respected throughout the entire
 update lifecycle AND patch works as expected!