### PR TITLE
Only generate a certificate if an existing in memory certificate isn't already set

### DIFF
--- a/pkg/server/options/serving.go
+++ b/pkg/server/options/serving.go
@@ -307,7 +307,7 @@ func (s *SecureServingOptions) MaybeDefaultWithSelfSignedCerts(publicAddress str
 		}
 	}
 
-	if !canReadCertAndKey {
+	if !canReadCertAndKey && s.ServerCert.GeneratedCert == nil {
 		// add either the bind address or localhost to the valid alternates
 		if s.BindAddress.IsUnspecified() {
 			alternateDNS = append(alternateDNS, "localhost")


### PR DESCRIPTION
I've got a use case where I'd like to be able to provide my own in memory generated certificate to tilt-apiserver. Current behavior only allows providing certificates via files, otherwise tilt-apiserver generates an in memory certificate for me. This change simply checks to see if someone has specified their own in memory certificate and skips the default generation logic if they have.



