### PR TITLE
apiserver: add WatchEvent as unversioned object

### DIFF
--- a/pkg/server/apiserver/apiserver.go
+++ b/pkg/server/apiserver/apiserver.go
@@ -29,14 +29,21 @@ import (
 func NewScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 
-	// we need to add the options to empty v1
-	// TODO fix the server code to avoid this
-	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	// Loosely adapted from
+	// https://github.com/kubernetes/apiextensions-apiserver/blob/a1e0ff9923b68731a7735f1c4168b6b3d0bd1027/pkg/apiserver/apiserver.go#L57
+	//
+	// Whitelist the unversioned API types
+	// for any apiserver.
 
-	// TODO: keep the generic API server from wanting this
-	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
+	unversioned := schema.GroupVersion{
+		Group:   "",
+		Version: "v1",
+	}
+	metav1.AddToGroupVersion(scheme, unversioned)
+
 	scheme.AddUnversionedTypes(unversioned,
 		&metav1.Status{},
+		&metav1.WatchEvent{},
 		&metav1.APIVersions{},
 		&metav1.APIGroupList{},
 		&metav1.APIGroup{},


### PR DESCRIPTION
borrowed from
https://github.com/kubernetes/apiextensions-apiserver/blob/a1e0ff9923b68731a7735f1c4168b6b3d0bd1027/pkg/apiserver/apiserver.go#L57

I'm not sure if this was leading to any
user-visible problems, but it was leading
to odd logs and weird serialization of
watch events.

Signed-off-by: Nick Santos <nick.santos@docker.com>
